### PR TITLE
feat: add workspace vs chat window essay

### DIFF
--- a/catmuse_me/Posts/Why Your AI Assistant Should Have a Workspace, Not Just a Chat Window.md
+++ b/catmuse_me/Posts/Why Your AI Assistant Should Have a Workspace, Not Just a Chat Window.md
@@ -1,0 +1,197 @@
+---
+title: Why Your AI Assistant Should Have a Workspace, Not Just a Chat Window
+date: 2026-03-21
+tags:
+  - Seed
+  - Dev
+publish: true
+description: Real AI collaboration does not happen inside a chat box. It happens inside a workspace with files, memory, tools, and reviewable output.
+aliases:
+comments: false
+---
+
+Most people still experience AI through a chat window.
+
+That interface is convenient, but it teaches the wrong mental model.
+
+It teaches you to think of an assistant as something you talk to, get an answer from, and forget. Ask a question. Get a paragraph. Start over tomorrow. This is fine for quick summaries, brainstorming, and one-off help.
+
+It falls apart the moment the work becomes real.
+
+Real work does not live inside the chat box. It lives in notes, drafts, repositories, issue trackers, editorial calendars, release watchlists, reminders, and half-finished plans. If your assistant cannot see, update, and organize those artifacts, then every conversation begins from zero. You are not collaborating. You are repeatedly re-briefing a very articulate stranger.
+
+That is why I think the next step for AI is not better conversation.
+
+It is better continuity.
+
+## The Chat Window Model Is Too Shallow
+
+The current default model of AI is basically this: a better chatbot.
+
+Smarter answers, cleaner prose, faster summaries. Useful, yes. But shallow.
+
+A chat-first assistant is usually:
+
+- stateless or weakly stateful
+- detached from the files where actual work happens
+- optimized for prompts instead of process
+- good at sounding helpful, bad at carrying responsibility
+
+This is why so many AI interactions feel impressive for ten minutes and useless by next week.
+
+The assistant can answer almost anything, but it cannot _stay with the work_.
+
+And staying with the work is the whole game.
+
+## Real Work Lives in Artifacts
+
+If you look closely, serious work always leaves a trail.
+
+A blog has drafts, outlines, tags, publishing rules, and review decisions.
+A software project has branches, issues, pull requests, changelogs, and release notes.
+A personal system has notes, memory files, calendars, reminders, and loose plans that slowly become concrete.
+
+These things are not side effects. They _are_ the work.
+
+A chat window can talk _about_ them.
+A workspace lets an assistant operate _within_ them.
+
+That difference is massive.
+
+If an assistant can only chat, it can suggest what you should do.
+If an assistant has a workspace, it can draft the article, update the plan, track the issue, monitor the release, prepare the branch, and hand you something reviewable.
+
+That is a completely different relationship.
+
+## Memory Alone Is Not Enough
+
+People often say the solution is memory.
+
+Give the assistant memory. Let it remember preferences. Let it remember names, projects, and prior context.
+
+Sure. That helps.
+
+But memory without a workspace is incomplete.
+
+Memory tells the assistant what matters.
+A workspace lets the assistant do something useful with that knowledge.
+
+Without a workspace, memory becomes vague autobiography. It knows you care about your blog, but it cannot update the editorial plan. It knows you care about a repository, but it cannot inspect the repo state. It knows you want a draft, but it has nowhere to put one except back into a chat bubble.
+
+That is not enough.
+
+What matters is not just what the assistant remembers.
+What matters is what it can inspect, modify, organize, and stage.
+
+## A Workspace Changes the Role of the Assistant
+
+Once an assistant has a workspace, its job stops being “answer my question” and starts becoming “help me move real work forward.”
+
+That workspace can include:
+
+- persistent files
+- editable drafts and plans
+- monitored repositories
+- tool access
+- scoped memory
+- operational logs
+- review checkpoints
+
+Now the assistant is no longer floating above the work. It is inside a system with structure.
+
+That changes what becomes possible.
+
+A workspace-based assistant can:
+
+- maintain an editorial plan instead of vaguely promising future ideas
+- watch a repository and tell you when issues or releases matter
+- draft an article directly into the content tree
+- create a branch and prepare a pull request
+- keep context across time without pretending to be magical
+
+This feels less like chatting with an oracle and more like working with software that actually belongs to you.
+
+Which, frankly, is a better direction.
+
+## Reviewability Matters More Than Autonomy
+
+There is a dumb fantasy floating around AI right now: full autonomy as a sign of progress.
+
+I do not buy it.
+
+For serious creative or technical work, the better model is not “AI does everything while you watch.”
+The better model is:
+
+- draft
+- stage
+- propose
+- review
+- merge
+
+That is why pull requests are a more useful metaphor than magic.
+
+If an assistant writes a blog post, I do not want it silently publishing.
+I want it to create a draft, make the changes visible, and let a human decide.
+
+If an assistant changes a codebase, same rule.
+If it reorganizes a knowledge system, same rule.
+
+The point is not to make the human disappear.
+The point is to make the human _more effective_ by moving fast inside a reviewable environment.
+
+Good AI should reduce friction, not remove judgment.
+
+## Chat Is an Interface, Not the System
+
+Telegram, Feishu, Discord, terminal, web UI—these are entry points.
+
+Useful ones, sometimes great ones. But they are not the real system.
+
+The real system is the workspace behind them.
+
+Without that layer, multi-channel AI is just the same amnesia in more places. You can message the assistant from five surfaces and still end up re-explaining the same project every week.
+
+With a workspace, the channel becomes what it should be: an interface.
+
+The assistant can meet you where you are, but the work still has a home.
+
+That home matters.
+
+## This Is Why Personal Software Feels Important Again
+
+Cloud chat interfaces trained us to rent intelligence one message at a time.
+
+You ask. It responds. The session scrolls upward and disappears into the fog.
+
+Workspace-based assistants push in the opposite direction. They bring back things that used to define personal software:
+
+- local files
+- private context
+- durable artifacts
+- personal workflows
+- bounded automation
+- human review
+
+That feels important.
+
+Not because nostalgia is fashionable, but because ownership matters.
+
+If AI is going to become part of real life, it cannot remain a detached answer machine living in a browser tab. It has to become part of an environment you can inspect, shape, and trust.
+
+That means files. Tools. Memory. Boundaries. History. Review.
+
+In other words: a workspace.
+
+## The Better Question
+
+The question is not whether your AI assistant is smart enough.
+
+The better question is: _what kind of environment is it allowed to work inside?_
+
+A chat window is enough if all you want is answers.
+
+A workspace is necessary if what you want is collaboration.
+
+And collaboration—not conversation—is where this starts to get interesting.
+
+[[AI]] | [[OpenClaw]] | [[Digital Garden]] | [[Writing]]


### PR DESCRIPTION
## Summary
- add a new essay: "Why Your AI Assistant Should Have a Workspace, Not Just a Chat Window"
- argue for workspace-based AI collaboration over chat-only interaction
- connect AI, continuity, reviewability, and personal software

## Why
This fits the site's evolving editorial direction: keep the digital garden / writing core, while opening a stronger AI and agent-workflow thread without turning the blog into a generic AI news feed.

## Notes
- new content only
- no layout or config changes