### PR TITLE
feat: add A Blog Is Not a Feed

### DIFF
--- a/catmuse_me/Posts/A Blog Is Not a Feed.md
+++ b/catmuse_me/Posts/A Blog Is Not a Feed.md
@@ -1,0 +1,188 @@
+---
+title: A Blog Is Not a Feed
+date: 2026-03-30
+tags:
+  - Seed
+  - Dev
+publish: true
+description: In the age of generative sameness, a blog should not behave like a feed. It should become a place for continuity, judgment, and connected thought.
+aliases:
+comments: false
+---
+
+The internet keeps trying to turn every form of writing into a feed.
+
+Shorter loops. Faster updates. More posts. More takes. More output. More visibility. More pressure to stay present, stay relevant, stay in motion.
+
+That logic makes sense for platforms whose business depends on churn.
+
+It makes less sense for a blog.
+
+A blog should not compete with the feed on its own terms. That is a losing game, and a stupid one. Feeds are built for speed, surface area, and replacement. A good blog should be built for continuity.
+
+That difference matters even more now, because AI has made generic content dramatically cheaper.
+
+## Generative Sameness Is a Real Problem
+
+The problem with AI is not only that it can generate text.
+
+The deeper problem is that it can generate an enormous amount of text that feels finished before it feels lived.
+
+It is easy now to produce polished paragraphs about almost anything:
+
+- how to build a second brain
+- how to use note-taking tools
+- how to think more clearly
+- how to write online
+- how AI is changing everything
+
+Most of it is not wrong.
+
+Most of it is also forgettable.
+
+That is because the internet does not only have a quantity problem. It has a sameness problem. The same structures. The same advice. The same metaphors. The same recycled confidence.
+
+AI did not invent that problem, but it massively accelerated it.
+
+Once generation became cheap, the cost of saying something dropped. The value of actually having something to say did not.
+
+## A Feed Rewards Motion, Not Memory
+
+Feeds are not evil. They just optimize for different things.
+
+A feed rewards:
+
+- speed
+- novelty
+- recency
+- emotional reaction
+- constant replacement
+
+Yesterday's post sinks. Today's post performs. Tomorrow's post arrives and pushes everything further down.
+
+That is not how good thinking usually develops.
+
+Good thinking is often recursive. It circles back. It contradicts itself. It sharpens through revision. It connects one note to another. It deepens because it remains available.
+
+That is why a feed is a terrible place to build a durable body of thought.
+
+It can help you distribute ideas.
+
+It is bad at helping those ideas stay alive.
+
+## A Blog Should Be a Place, Not a Stream
+
+This is the mistake I think many people make when they bring blog habits into the age of AI.
+
+They keep the medium, but import the logic of the feed.
+
+So the blog becomes:
+
+- a dumping ground for frequent updates
+- a cleaner-looking social timeline
+- a personal SEO machine
+- a place to stockpile output
+
+That misses the point.
+
+A blog is valuable precisely because it can be slower, more connected, and less disposable.
+
+A post should not only be publishable. It should be placeable.
+
+It should belong somewhere in a larger structure of thought.
+
+That means it should have neighbors. It should connect to prior writing. It should leave trails forward. It should create backlinks worth following.
+
+That is closer to a [[digital-garden-mindset|digital garden]] than a content calendar optimized for volume.
+
+## Writing Is Not Just Publishing
+
+One reason feeds flatten writing is that they collapse everything into the same act: publish.
+
+But real writing has more stages than that.
+
+There is:
+
+- noticing
+- collecting fragments
+- drafting
+- testing language
+- revising position
+- connecting ideas
+- then publishing
+
+A blog can hold more of that process than a feed can.
+
+It can preserve essays, notes, fragments, and links between them. It can show not just what you think now, but how your thinking moves.
+
+That is why I still care about blogs, and why I care even more in an AI-heavy environment.
+
+When generation becomes easy, structure matters more.
+
+When output becomes cheap, judgment matters more.
+
+When everyone can publish, curation becomes part of authorship.
+
+## The Point Is Not To Post Less. The Point Is To Mean More.
+
+This does not mean a blog must be rare, precious, or overly polished.
+
+It also does not mean short writing is bad.
+
+The point is simpler.
+
+A blog should not be governed by the logic of disposable content.
+
+If a post exists only to keep the machine warm, it probably does not need to exist.
+
+If a note helps connect three other ideas and makes the whole graph stronger, then even a short note can matter.
+
+That is one reason I keep coming back to [[Expression over Collection]]. The value is not in producing more things. The value is in building a body of expression that actually belongs to you.
+
+And that is also why I distrust a lot of second-brain content. Too much of it mistakes accumulation for thinking, and publication for clarity. The trap is old. AI just makes it easier to scale. [[the-second-brain-trap|That trap does not disappear because the tools get better.]]
+
+## AI Should Raise the Bar, Not Lower It
+
+There is a lazy way to use AI in writing.
+
+You can let it fill the page, smooth the transitions, produce the examples, and fake the center of gravity.
+
+That usually creates competent emptiness.
+
+There is also a better way.
+
+You can use AI to help clarify, compare drafts, expose weak spots, test structure, or reduce friction around revision. In that role, AI supports writing without replacing the need for an actual point of view.
+
+That is the standard I care about.
+
+Not “did AI help make this faster?”
+
+But “did this piece become sharper, truer, and more connected?”
+
+If the answer is no, speed is irrelevant.
+
+## A Blog Is Where Continuity Wins
+
+Feeds are useful for distribution.
+
+They are not good containers for continuity.
+
+A blog can still be that container.
+
+Not because it is nostalgic. Not because it is pure. Not because it is somehow above the internet.
+
+But because it can still do something the feed struggles to do: hold connected thought over time.
+
+That matters more now, not less.
+
+Especially when the internet is filling with fluent, generic text.
+
+In that environment, the job of a blog is not to post constantly.
+
+It is to become a place where judgment accumulates.
+
+A place where ideas link, return, and evolve.
+
+A place that feels less like a timeline and more like a mind.
+
+[[A Digital Garden for the AI Age]] | [[digital-garden-mindset]] | [[Expression over Collection]] | [[the-second-brain-trap]]


### PR DESCRIPTION
## Summary
- add a new essay: "A Blog Is Not a Feed"
- argue for blogs as places of continuity rather than churn
- connect the piece to existing themes: digital gardens, expression, second-brain critique, and AI-era writing

## Why
This follows the editorial direction we already set: keep the site rooted in writing, judgment, and connected thought, while responding directly to the problem of generative sameness.

## Notes
- publish-ready content only
- includes internal links to related posts
- no layout or config changes