### PR TITLE
feat: add post on knowledge tools becoming agent workspaces

### DIFF
--- a/catmuse_me/Posts/Knowledge Tools Are Becoming Agent Workspaces.md
+++ b/catmuse_me/Posts/Knowledge Tools Are Becoming Agent Workspaces.md
@@ -1,0 +1,310 @@
+---
+title: Knowledge Tools Are Becoming Agent Workspaces
+date: 2026-04-13
+tags:
+  - Seed
+  - AI
+  - Knowledge Management
+publish: true
+description: Knowledge tools are no longer just places to store notes. They are slowly becoming environments where agents can read, act, remember, and move work forward.
+aliases:
+comments: false
+---
+
+For years, knowledge tools mostly answered one question:
+
+How do I store what I know?
+
+That was the game.
+
+Capture better. Organize better. Search faster. Tag smarter. Build a second brain. Build a personal wiki. Build a system that feels less like chaos and more like control.
+
+That framing is not wrong.
+
+It is just no longer enough.
+
+A new shift is becoming visible now, and once you see it, it is hard to unsee.
+
+Knowledge tools are starting to move from note containers to agent workspaces.
+
+That means the important question is changing.
+
+Not just:
+
+- how do I save information?
+- how do I find it later?
+
+But also:
+
+- how can an agent operate inside it?
+- how can context persist across work?
+- how can knowledge become actionable instead of merely archived?
+
+That is a much bigger transition than adding an AI panel to a sidebar.
+
+## The Old Model Was Storage-Centered
+
+Most knowledge software was designed around human retrieval.
+
+You wrote something down so that your future self could come back and find it.
+
+This produced a familiar stack of features:
+
+- notes
+- folders
+- backlinks
+- search
+- tags
+- databases
+- snippets
+- highlights
+
+Useful, yes.
+
+But the basic model stayed the same.
+
+The tool stored information.
+The human returned to operate on it.
+
+Even many “AI features” still fit that old model.
+
+They summarize a page. Rewrite a paragraph. Extract action items from a meeting. Generate a title. Clean up your mess a little.
+
+Helpful, sometimes.
+
+Still mostly assistant garnish on top of a storage product.
+
+## The New Question Is Operational
+
+What changes everything is not whether a tool has AI.
+
+It is whether the tool can become a place where an agent actually works.
+
+That is a different standard.
+
+An agent workspace is not just a prettier note app with autocomplete. It is an environment where an agent can:
+
+- read existing context
+- act on structured and unstructured information
+- update artifacts
+- follow local rules
+- keep continuity across time
+- leave reviewable output behind
+
+That last part matters.
+
+The future is not “the AI knows everything.”
+The future is “the AI can work somewhere.”
+
+And that somewhere increasingly looks like a knowledge environment.
+
+## The Signals Are Getting Harder to Ignore
+
+Over the last few weeks, the pattern has been unusually consistent.
+
+Notion has been pushing beyond passive note-taking toward a more operational AI layer, with things like custom skills, meeting-note controls, chat sharing, and richer interaction surfaces.
+
+Obsidian, from a very different direction, keeps strengthening its automation surface: CLI improvements, scriptability, and a community that increasingly treats the vault as something agents and coding tools can operate inside, not just something humans type into.
+
+At the same time, a separate wave of projects is attacking the memory problem directly.
+
+You can see it in tools and ideas around:
+
+- context engineering
+- external memory
+- decision logs
+- repo-aware design files
+- agent-readable specs
+- long-term project brains
+
+These are not isolated gimmicks.
+
+They are all circling the same conclusion:
+
+> Knowledge becomes dramatically more valuable once an agent can consume it, update it, and act through it.
+
+That is the real shift.
+
+## A Note App Is Not Yet a Workspace
+
+This is where a lot of products still get stuck.
+
+They take the old storage-centered interface and bolt an AI prompt box onto it.
+
+Now the app can answer questions about your notes.
+Fine.
+
+But answering questions is not the same thing as participating in work.
+
+A real workspace has to support a loop more like this:
+
+1. context is stored in durable artifacts
+2. the agent can inspect those artifacts
+3. the agent can produce edits, drafts, tasks, or connections
+4. the human can review what changed
+5. the system keeps the new state
+
+That loop is much more important than “ask AI about this page.”
+
+If the tool cannot hold that loop, then it is still mostly a container.
+
+## Why This Matters More in the Age of Agents
+
+Chat-based AI trained people to think in sessions.
+
+Ask something. Get an answer. Move on.
+
+That is fine for one-off help.
+It is terrible for continuity.
+
+Real work does not happen in isolated chat bubbles. It happens in:
+
+- drafts
+- issue lists
+- project notes
+- editorial plans
+- research fragments
+- meeting summaries
+- decisions that need to be revisited later
+
+If every conversation starts from scratch, you do not have collaboration. You have repeated re-briefing.
+
+That is exactly why agent workspaces matter.
+
+A good workspace gives the agent somewhere to stay with the work.
+
+Not magically.
+Not autonomously in the stupid sci-fi sense.
+But concretely.
+
+It can read the plan. Update the brief. connect a note. draft the post. prepare the branch. summarize the decision. track what changed.
+
+That is much closer to real leverage.
+
+## The Most Valuable Layer Is Not the Chat Layer
+
+I think a lot of people are still looking in the wrong place.
+
+They focus on the chat interface because it is the most visible part.
+
+But the chat layer is just the entrance.
+The real moat is the operating layer underneath it.
+
+That layer includes things like:
+
+- local files
+- structured notes
+- project memory
+- explicit rules
+- editable plans
+- versioned outputs
+- searchable history
+- agent-readable context
+
+Once that layer gets good enough, the front-end matters less.
+
+Telegram, Discord, a terminal, a web app, a note pane, a voice interface, all of these become surfaces.
+
+The actual power sits in the continuity of the workspace.
+
+## This Also Changes What Knowledge Management Means
+
+For a long time, knowledge management culture was obsessed with collection.
+
+Capture more.
+Clip more.
+Link more.
+Store more.
+
+That mindset produced some useful tools and some absolute bullshit.
+
+Because the hard problem was never only accumulation.
+The hard problem was turning knowledge into ongoing action and judgment.
+
+That is why the next generation of knowledge tools will not win by storing the most information.
+
+They will win by helping people and agents do better work inside a persistent context.
+
+That means the center of gravity shifts:
+
+- from collection to operation
+- from retrieval to execution
+- from notes as archives to notes as live context
+- from passive memory to active working memory
+
+That is a deeper change than most product marketing currently admits.
+
+## The Best Tools Will Feel Less Like Libraries and More Like Studios
+
+A library stores finished material.
+A studio supports active making.
+
+Knowledge tools used to feel mostly like libraries.
+
+The better ones are starting to feel like studios.
+
+A studio for thought.
+A studio for planning.
+A studio where agents can participate without being allowed to run wild.
+
+That last part matters too.
+
+Good agent workspaces should not be designed around blind autonomy.
+They should be designed around:
+
+- bounded action
+- visible edits
+- durable context
+- human review
+- continuity over time
+
+In other words, less magic, more working system.
+
+## What I Think Happens Next
+
+I do not think every note app suddenly becomes an agent platform.
+A lot of them will slap AI onto the surface and call it progress.
+
+But the stronger direction is already visible.
+
+The winners will probably be the tools that combine three things well:
+
+1. durable knowledge storage
+2. operational surfaces for agents
+3. reviewable workflows for humans
+
+That combination is much more important than having the flashiest demo.
+
+Because once an agent can work inside your knowledge environment, the knowledge tool stops being a passive repository.
+
+It becomes infrastructure.
+
+And infrastructure is where the real value compounds.
+
+## The Better Framing
+
+So no, I do not think the interesting story is “note-taking apps now have AI.”
+
+That framing is too shallow.
+
+The more important story is this:
+
+> Knowledge management tools are slowly becoming environments where agents can operate.
+
+That is a different category.
+
+It changes what notes are for.
+It changes what memory means.
+It changes what it means to collaborate with software.
+
+And I think it is one of the most important shifts happening right now in personal software.
+
+Not because it sounds futuristic.
+
+Because it finally points toward a more useful question than “what can the model say?”
+
+The better question is:
+
+What kind of workspace can it actually work in?
+
+[[AI]] | [[Knowledge Management]] | [[Digital Garden]] | [[OpenClaw]]


### PR DESCRIPTION
## Summary
- add a new blog post on how knowledge tools are shifting from note containers to agent workspaces
- connect recent signals across Notion, Obsidian, and agent memory/context tooling
- frame the trend around operational context, continuity, and reviewable workflows

## Why
This turns the recent signal sweep into a sharper blog essay for catmuse.me and fits the site's existing digital garden / AI collaboration themes.